### PR TITLE
Get data sources from boot data instead /api/datasources

### DIFF
--- a/src/annotations_ctrl.js
+++ b/src/annotations_ctrl.js
@@ -35,12 +35,9 @@ export class AnnotationsCtrl extends PanelCtrl {
         this.$http = $http;
 
         // get influx datasources
-        this.backendSrv.get('/api/datasources')
-            .then((result) => {
-                this.availableDatasources = _.filter(result, {"type": "influxdb"});
-                this.selectedDatasource = this.availableDatasources[1];
-            });
-
+        this.availableDatasources = _.filter(window.grafanaBootData.settings.datasources, {"type": "influxdb"});
+        this.selectedDatasource = this.availableDatasources[1];
+        
         this.annotation = annotationDefaults;
         this.editor = editorDefaults;
 


### PR DESCRIPTION
/api/datasources contains possibly sensitive information and can not be accessed with role Editor or Viewer. Grafana boot data contains names and types of datasources. Fixes #8 

I'm not sure what is the right procedure to update the /dist folder so I did not update it. I can migrate this change also to the dist folder if required